### PR TITLE
Add splash and onboarding screens

### DIFF
--- a/NixblyApp/App.tsx
+++ b/NixblyApp/App.tsx
@@ -1,7 +1,26 @@
+import React, { useEffect, useState } from 'react';
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, Text, View } from 'react-native';
+import SplashScreen from './screens/SplashScreen';
+import OnboardingScreen from './screens/OnboardingScreen';
 
 export default function App() {
+  const [showSplash, setShowSplash] = useState(true);
+  const [showOnboarding, setShowOnboarding] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setShowSplash(false), 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (showSplash) {
+    return <SplashScreen />;
+  }
+
+  if (showOnboarding) {
+    return <OnboardingScreen onDone={() => setShowOnboarding(false)} />;
+  }
+
   return (
     <View style={styles.container}>
       <Text>Open up App.tsx to start working on your app!</Text>

--- a/NixblyApp/screens/OnboardingScreen.tsx
+++ b/NixblyApp/screens/OnboardingScreen.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+
+interface Props {
+  onDone: () => void;
+}
+
+export default function OnboardingScreen({ onDone }: Props) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Welcome to NixblyApp</Text>
+      <Text style={styles.description}>This is the onboarding screen.</Text>
+      <TouchableOpacity style={styles.button} onPress={onDone}>
+        <Text style={styles.buttonText}>Get Started</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+    paddingHorizontal: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 10,
+  },
+  description: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  button: {
+    backgroundColor: '#000',
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 5,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+});

--- a/NixblyApp/screens/SplashScreen.tsx
+++ b/NixblyApp/screens/SplashScreen.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, Text, StyleSheet, Image } from 'react-native';
+
+export default function SplashScreen() {
+  return (
+    <View style={styles.container}>
+      <Image source={require('../assets/splash-icon.png')} style={styles.image} />
+      <Text style={styles.title}>NixblyApp</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  image: {
+    width: 120,
+    height: 120,
+    marginBottom: 20,
+    resizeMode: 'contain',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
## Summary
- introduce splash screen component
- add single onboarding screen with "Get Started" button
- update app entry to show splash then onboarding before main content

## Testing
- `npx tsc --noEmit` *(fails: cannot find module '@tsconfig/react-native/tsconfig.json'; multiple type errors)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689adc21fd88832a901735630e213afd